### PR TITLE
Mark Room DAO tests as internal

### DIFF
--- a/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/database/ItemsDaoTest.kt
+++ b/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/database/ItemsDaoTest.kt
@@ -13,7 +13,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class ItemsDaoTest {
+internal class ItemsDaoTest {
     private lateinit var db: ItemsDatabase
     private lateinit var dao: ItemsDao
 

--- a/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/database/RemoteKeysDaoTest.kt
+++ b/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/database/RemoteKeysDaoTest.kt
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class RemoteKeysDaoTest {
+internal class RemoteKeysDaoTest {
     private lateinit var db: ItemsDatabase
     private lateinit var dao: RemoteKeysDao
 


### PR DESCRIPTION
## Summary
- mark ItemsDaoTest and RemoteKeysDaoTest as internal to align with visibility guidelines

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_690480cbbe18832eb3fa58b15e12ea0b