### PR TITLE
Rename fakes to use suffix naming

### DIFF
--- a/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/ItemsLocalDataSourceFake.kt
+++ b/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/ItemsLocalDataSourceFake.kt
@@ -1,7 +1,7 @@
 package com.sottti.android.app.template.data.items.datasource.local
 
 import androidx.paging.PagingSource
-import com.sottti.android.app.template.data.items.datasource.local.mapper.FakeItemMappingPagingSource
+import com.sottti.android.app.template.data.items.datasource.local.mapper.ItemMappingPagingSourceFake
 import com.sottti.android.app.template.data.items.datasource.local.model.RemoteKeysRoomModel
 import com.sottti.android.app.template.model.Item
 import com.sottti.android.app.template.model.ItemId
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
-internal class FakeItemsLocalDataSource : ItemsLocalDataSource {
+internal class ItemsLocalDataSourceFake : ItemsLocalDataSource {
 
     val saved: MutableList<Item> = mutableListOf()
     var remoteKeys: RemoteKeysRoomModel? = null
@@ -31,7 +31,7 @@ internal class FakeItemsLocalDataSource : ItemsLocalDataSource {
             .distinctUntilChanged()
 
     override fun observeItems(): PagingSource<Int, Item> =
-        FakeItemMappingPagingSource(saved)
+        ItemMappingPagingSourceFake(saved)
 
     override suspend fun isExpired(itemId: ItemId): Boolean = itemId in expiredIds
 

--- a/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/ItemsLocalDataSourceImplTest.kt
+++ b/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/ItemsLocalDataSourceImplTest.kt
@@ -1,10 +1,11 @@
 package com.sottti.android.app.template.data.items.datasource.local
 
 import com.google.common.truth.Truth.assertThat
-import com.sottti.android.app.template.data.items.datasource.local.database.FakeItemsDao
-import com.sottti.android.app.template.data.items.datasource.local.database.FakeRemoteKeysDao
+import com.sottti.android.app.template.data.items.datasource.local.database.ItemsDaoFake
+import com.sottti.android.app.template.data.items.datasource.local.database.RemoteKeysDaoFake
 import com.sottti.android.app.template.data.items.datasource.local.mapper.toRoom
 import com.sottti.android.app.template.data.items.datasource.local.model.RemoteKeysRoomModel
+import com.sottti.android.app.template.data.items.datasource.local.TimeProviderFake
 import com.sottti.android.app.template.fixtures.fixtureItem1
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -12,16 +13,16 @@ import org.junit.Test
 
 internal class ItemsLocalDataSourceImplTest {
 
-    private lateinit var itemsDao: FakeItemsDao
+    private lateinit var itemsDao: ItemsDaoFake
     private lateinit var localDataSource: ItemsLocalDataSource
-    private lateinit var remoteKeysDao: FakeRemoteKeysDao
-    private lateinit var timeProvider: FakeTimeProvider
+    private lateinit var remoteKeysDao: RemoteKeysDaoFake
+    private lateinit var timeProvider: TimeProviderFake
 
     @Before
     fun setUp() {
-        itemsDao = FakeItemsDao()
-        remoteKeysDao = FakeRemoteKeysDao()
-        timeProvider = FakeTimeProvider()
+        itemsDao = ItemsDaoFake()
+        remoteKeysDao = RemoteKeysDaoFake()
+        timeProvider = TimeProviderFake()
         localDataSource = ItemsLocalDataSourceImpl(
             itemsDao = itemsDao,
             remoteKeysDao = remoteKeysDao,

--- a/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/TimeProviderFake.kt
+++ b/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/TimeProviderFake.kt
@@ -2,7 +2,7 @@ package com.sottti.android.app.template.data.items.datasource.local
 
 import java.time.Instant
 
-internal class FakeTimeProvider(
+internal class TimeProviderFake(
     initialTime: Long = Instant.EPOCH.toEpochMilli(),
 ) : TimeProvider {
 

--- a/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/database/ItemsDaoFake.kt
+++ b/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/database/ItemsDaoFake.kt
@@ -1,7 +1,7 @@
 package com.sottti.android.app.template.data.items.datasource.local.database
 
 import androidx.paging.PagingSource
-import com.sottti.android.app.template.data.items.datasource.local.mapper.FakeItemMappingPagingSource
+import com.sottti.android.app.template.data.items.datasource.local.mapper.ItemMappingPagingSourceFake
 import com.sottti.android.app.template.data.items.datasource.local.mapper.toDomain
 import com.sottti.android.app.template.data.items.datasource.local.model.ItemRoomModel
 import kotlinx.coroutines.flow.Flow
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
-internal class FakeItemsDao : ItemsDao {
+internal class ItemsDaoFake : ItemsDao {
     val saved = mutableListOf<ItemRoomModel>()
     var clearCalled = false
     var upsertCalled = false
@@ -17,7 +17,7 @@ internal class FakeItemsDao : ItemsDao {
     private val itemsFlow = MutableStateFlow<List<ItemRoomModel>>(emptyList())
 
     override fun observeItems(): PagingSource<Int, ItemRoomModel> {
-        return FakeItemMappingPagingSource(saved.map { it.toDomain() }.toMutableList())
+        return ItemMappingPagingSourceFake(saved.map { it.toDomain() }.toMutableList())
             .let { it as PagingSource<Int, ItemRoomModel> }
     }
 

--- a/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/database/RemoteKeysDaoFake.kt
+++ b/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/database/RemoteKeysDaoFake.kt
@@ -2,7 +2,7 @@ package com.sottti.android.app.template.data.items.datasource.local.database
 
 import com.sottti.android.app.template.data.items.datasource.local.model.RemoteKeysRoomModel
 
-internal class FakeRemoteKeysDao : RemoteKeysDao {
+internal class RemoteKeysDaoFake : RemoteKeysDao {
     var keys: RemoteKeysRoomModel? = null
     var getCalled = false
     var upsertCalled = false

--- a/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/fixtures/ItemRoomModelFixtures.kt
+++ b/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/fixtures/ItemRoomModelFixtures.kt
@@ -1,10 +1,10 @@
 package com.sottti.android.app.template.data.items.datasource.local.fixtures
 
-import com.sottti.android.app.template.data.items.datasource.local.FakeTimeProvider
+import com.sottti.android.app.template.data.items.datasource.local.TimeProviderFake
 import com.sottti.android.app.template.data.items.datasource.local.mapper.toRoom
 import com.sottti.android.app.template.fixtures.fixtureItem1
 import com.sottti.android.app.template.fixtures.fixtureItem2
 
-private val now = FakeTimeProvider().now()
+private val now = TimeProviderFake().now()
 internal val fixtureItem1RoomModel = fixtureItem1.toRoom(now)
 internal val fixtureItem2RoomModel = fixtureItem2.toRoom(now)

--- a/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/mapper/ItemMappingPagingSourceFake.kt
+++ b/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/mapper/ItemMappingPagingSourceFake.kt
@@ -4,7 +4,7 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.sottti.android.app.template.model.Item
 
-internal class FakeItemMappingPagingSource(
+internal class ItemMappingPagingSourceFake(
     private val saved: MutableList<Item>,
 ) : PagingSource<Int, Item>() {
 

--- a/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/mapper/ItemMappingPagingSourceTest.kt
+++ b/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/mapper/ItemMappingPagingSourceTest.kt
@@ -27,7 +27,7 @@ internal class ItemMappingPagingSourceTest {
             itemsBefore = itemsBefore,
             itemsAfter = itemsAfter,
         )
-        val roomPagingSource = FakeRoomPagingSource { roomPage }
+        val roomPagingSource = RoomPagingSourceFake { roomPage }
 
         val page = ItemMappingPagingSource(roomPagingSource).load(
             PagingSource.LoadParams.Refresh(
@@ -52,7 +52,7 @@ internal class ItemMappingPagingSourceTest {
     @Test
     fun `get refresh key mirrors anchor logic`() {
         val mapper = ItemMappingPagingSource(
-            FakeRoomPagingSource { PagingSource.LoadResult.Invalid() }
+            RoomPagingSourceFake { PagingSource.LoadResult.Invalid() }
         )
 
         val page1 = PagingSource.LoadResult.Page(
@@ -84,7 +84,7 @@ internal class ItemMappingPagingSourceTest {
     @Test
     fun `propagates error`() = runTest {
         val boom = IllegalStateException("boom")
-        val roomPagingSource = FakeRoomPagingSource { PagingSource.LoadResult.Error(boom) }
+        val roomPagingSource = RoomPagingSourceFake { PagingSource.LoadResult.Error(boom) }
 
         val result = ItemMappingPagingSource(roomPagingSource).load(
             PagingSource.LoadParams.Refresh(key = null, loadSize = 10, placeholdersEnabled = false)
@@ -95,7 +95,7 @@ internal class ItemMappingPagingSourceTest {
 
     @Test
     fun `propagates invalid`() = runTest {
-        val roomPagingSource = FakeRoomPagingSource { PagingSource.LoadResult.Invalid() }
+        val roomPagingSource = RoomPagingSourceFake { PagingSource.LoadResult.Invalid() }
 
         val result = ItemMappingPagingSource(roomPagingSource).load(
             PagingSource.LoadParams.Refresh(key = null, loadSize = 10, placeholdersEnabled = false)
@@ -106,7 +106,7 @@ internal class ItemMappingPagingSourceTest {
 
     @Test
     fun `when underlying source is invalid, then load returns invalid`() = runTest {
-        val roomPagingSource = FakeRoomPagingSource {
+        val roomPagingSource = RoomPagingSourceFake {
             PagingSource.LoadResult.Page(emptyList(), null, null, 0, 0)
         }
         val mapper = ItemMappingPagingSource(roomPagingSource)
@@ -124,7 +124,7 @@ internal class ItemMappingPagingSourceTest {
     @Test
     fun `getRefreshKey falls back to nextKey - 1 when prevKey null`() {
         val mapper = ItemMappingPagingSource(
-            FakeRoomPagingSource { PagingSource.LoadResult.Invalid() }
+            RoomPagingSourceFake { PagingSource.LoadResult.Invalid() }
         )
         val page = PagingSource.LoadResult.Page(
             data = listOf(fixtureItem1),

--- a/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/mapper/ItemsLocalDataMapperTest.kt
+++ b/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/mapper/ItemsLocalDataMapperTest.kt
@@ -1,7 +1,7 @@
 package com.sottti.android.app.template.data.items.datasource.local.mapper
 
 import com.google.common.truth.Truth.assertThat
-import com.sottti.android.app.template.data.items.datasource.local.FakeTimeProvider
+import com.sottti.android.app.template.data.items.datasource.local.TimeProviderFake
 import com.sottti.android.app.template.data.items.datasource.local.fixtures.fixtureItem1RoomModel
 import com.sottti.android.app.template.data.items.datasource.local.fixtures.fixtureItem2RoomModel
 import com.sottti.android.app.template.fixtures.fixtureItem1
@@ -9,7 +9,7 @@ import com.sottti.android.app.template.fixtures.fixtureItem2
 import com.sottti.android.app.template.model.Item
 import org.junit.Test
 
-private val now = FakeTimeProvider().now()
+private val now = TimeProviderFake().now()
 
 internal class ItemsLocalDataMapperTest {
 

--- a/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/mapper/RoomPagingSourceFake.kt
+++ b/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/local/mapper/RoomPagingSourceFake.kt
@@ -4,7 +4,7 @@ import androidx.paging.PagingSource
 import androidx.paging.PagingState
 import com.sottti.android.app.template.data.items.datasource.local.model.ItemRoomModel
 
-internal class FakeRoomPagingSource(
+internal class RoomPagingSourceFake(
     private val loader: suspend (LoadParams<Int>) -> LoadResult<Int, ItemRoomModel>,
 ) : PagingSource<Int, ItemRoomModel>() {
     override fun getRefreshKey(state: PagingState<Int, ItemRoomModel>): Int? = null

--- a/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/remote/ItemsRemoteDataSourceImplTest.kt
+++ b/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/remote/ItemsRemoteDataSourceImplTest.kt
@@ -3,7 +3,7 @@ package com.sottti.android.app.template.data.items.datasource.remote
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.onSuccess
 import com.google.common.truth.Truth.assertThat
-import com.sottti.android.app.template.data.items.datasource.remote.api.FakeItemsApiCalls
+import com.sottti.android.app.template.data.items.datasource.remote.api.ItemsApiCallsFake
 import com.sottti.android.app.template.data.items.datasource.remote.fixtures.fixtureItem1ApiModel
 import com.sottti.android.app.template.data.items.datasource.remote.mapper.toDomain
 import com.sottti.android.app.template.data.items.datasource.remote.model.PageNumberApiModel
@@ -15,12 +15,12 @@ import org.junit.Test
 
 internal class ItemsRemoteDataSourceImplTest {
 
-    private lateinit var apiCalls: FakeItemsApiCalls
+    private lateinit var apiCalls: ItemsApiCallsFake
     private lateinit var dataSource: ItemsRemoteDataSourceImpl
 
     @Before
     fun setUp() {
-        apiCalls = FakeItemsApiCalls()
+        apiCalls = ItemsApiCallsFake()
         dataSource = ItemsRemoteDataSourceImpl(api = apiCalls)
     }
 

--- a/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/remote/api/ItemsApiCallsFake.kt
+++ b/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/datasource/remote/api/ItemsApiCallsFake.kt
@@ -1,38 +1,38 @@
-package com.sottti.android.app.template.data.items.datasource.remote
+package com.sottti.android.app.template.data.items.datasource.remote.api
 
 import com.github.michaelbull.result.Err
 import com.github.michaelbull.result.Ok
 import com.github.michaelbull.result.annotation.UnsafeResultErrorAccess
 import com.github.michaelbull.result.annotation.UnsafeResultValueAccess
+import com.sottti.android.app.template.data.items.datasource.remote.model.ItemApiModel
 import com.sottti.android.app.template.data.items.datasource.remote.model.PageNumberApiModel
 import com.sottti.android.app.template.data.items.datasource.remote.model.PageSizeApiModel
 import com.sottti.android.app.template.data.network.model.ExceptionApiModel.Unknown
-import com.sottti.android.app.template.domain.core.models.Result
-import com.sottti.android.app.template.model.Item
+import com.sottti.android.app.template.data.network.model.ResultApiModel
 import com.sottti.android.app.template.model.ItemId
 
-internal class FakeItemsRemoteDataSource : ItemsRemoteDataSource {
+internal class ItemsApiCallsFake : ItemsApiCalls {
 
-    private var response: Result<List<Item>>? = null
+    private var response: ResultApiModel<List<ItemApiModel>>? = null
 
     var lastCalledPageNumber: PageNumberApiModel? = null
     var lastCalledPageSize: PageSizeApiModel? = null
 
-    fun setSuccessResponse(items: List<Item>) {
+    fun setSuccessResponse(items: List<ItemApiModel>) {
         response = Ok(items)
     }
 
-    fun setErrorResponse(exception: Exception) {
-        response = Err(exception)
+    fun setErrorResponse(exception: Throwable) {
+        response = Err(Unknown(exception.message ?: "Unknown"))
     }
 
     @OptIn(UnsafeResultValueAccess::class, UnsafeResultErrorAccess::class)
-    override suspend fun getItem(itemId: ItemId): Result<Item> {
+    override suspend fun getItem(itemId: ItemId): ResultApiModel<ItemApiModel> {
         val listResult = response
         return when {
             listResult == null -> throw IllegalStateException("Test response was not set in fake")
             listResult.isOk -> {
-                val item = listResult.value.firstOrNull { it.id.value == itemId.value }
+                val item = listResult.value.firstOrNull { it.id == itemId.value }
                     ?: return Err(Unknown("Item with id ${itemId.value} not found"))
                 Ok(item)
             }
@@ -45,10 +45,10 @@ internal class FakeItemsRemoteDataSource : ItemsRemoteDataSource {
     override suspend fun getItems(
         pageNumber: PageNumberApiModel,
         pageSize: PageSizeApiModel,
-    ): Result<List<Item>> {
+    ): ResultApiModel<List<ItemApiModel>> {
         lastCalledPageNumber = pageNumber
         lastCalledPageSize = pageSize
 
-        return response ?: throw IllegalStateException("Test response was not set in the fake")
+        return response ?: throw IllegalStateException("Test response was not set in fake")
     }
 }

--- a/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/mediator/ItemsRemoteMediatorTest.kt
+++ b/data/items/src/test/kotlin/com/sottti/android/app/template/data/items/mediator/ItemsRemoteMediatorTest.kt
@@ -7,9 +7,9 @@ import androidx.paging.PagingState
 import androidx.paging.RemoteMediator.MediatorResult.Error
 import androidx.paging.RemoteMediator.MediatorResult.Success
 import com.google.common.truth.Truth.assertThat
-import com.sottti.android.app.template.data.items.datasource.local.FakeItemsLocalDataSource
+import com.sottti.android.app.template.data.items.datasource.local.ItemsLocalDataSourceFake
 import com.sottti.android.app.template.data.items.datasource.local.model.RemoteKeysRoomModel
-import com.sottti.android.app.template.data.items.datasource.remote.FakeItemsRemoteDataSource
+import com.sottti.android.app.template.data.items.datasource.remote.ItemsRemoteDataSourceFake
 import com.sottti.android.app.template.fixtures.listOfMultipleItems
 import com.sottti.android.app.template.model.Item
 import kotlinx.coroutines.test.runTest
@@ -19,8 +19,8 @@ import org.junit.Test
 @OptIn(ExperimentalPagingApi::class)
 internal class ItemsRemoteMediatorTest {
 
-    private lateinit var localDataSource: FakeItemsLocalDataSource
-    private lateinit var remoteDataSource: FakeItemsRemoteDataSource
+    private lateinit var localDataSource: ItemsLocalDataSourceFake
+    private lateinit var remoteDataSource: ItemsRemoteDataSourceFake
     private lateinit var mediator: ItemsRemoteMediator
 
     private val pagingState = PagingState<Int, Item>(
@@ -32,8 +32,8 @@ internal class ItemsRemoteMediatorTest {
 
     @Before
     fun setUp() {
-        localDataSource = FakeItemsLocalDataSource()
-        remoteDataSource = FakeItemsRemoteDataSource()
+        localDataSource = ItemsLocalDataSourceFake()
+        remoteDataSource = ItemsRemoteDataSourceFake()
         mediator = ItemsRemoteMediator(
             localDataSource = localDataSource,
             remoteDataSource = remoteDataSource

--- a/data/settings/src/main/kotlin/com/sottti/android/app/template/data/settings/datasource/local/managers/SystemColorContrastManagerFake.kt
+++ b/data/settings/src/main/kotlin/com/sottti/android/app/template/data/settings/datasource/local/managers/SystemColorContrastManagerFake.kt
@@ -4,7 +4,7 @@ import com.sottti.android.app.template.domain.core.models.SystemColorContrast
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
-internal class FakeSystemColorContrastManager(
+internal class SystemColorContrastManagerFake(
     default: SystemColorContrast,
 ) : SystemColorContrastManager {
 

--- a/data/settings/src/main/kotlin/com/sottti/android/app/template/data/settings/datasource/local/managers/ThemeManagerFake.kt
+++ b/data/settings/src/main/kotlin/com/sottti/android/app/template/data/settings/datasource/local/managers/ThemeManagerFake.kt
@@ -4,7 +4,7 @@ import com.sottti.android.app.template.domain.core.models.SystemTheme
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
-internal class FakeThemeManager(
+internal class ThemeManagerFake(
     default: SystemTheme,
 ) : ThemeManager {
 

--- a/data/settings/src/main/kotlin/com/sottti/android/app/template/data/settings/datasource/local/managers/UiModeManagerFake.kt
+++ b/data/settings/src/main/kotlin/com/sottti/android/app/template/data/settings/datasource/local/managers/UiModeManagerFake.kt
@@ -3,7 +3,7 @@ package com.sottti.android.app.template.data.settings.datasource.local.managers
 import android.os.Build
 import androidx.annotation.RequiresApi
 
-internal class FakeUiModeManager : UiModeManager {
+internal class UiModeManagerFake : UiModeManager {
 
     private var contrastValue: Float? = null
 

--- a/data/settings/src/test/kotlin/com/sottti/android/app/template/data/settings/datasource/local/SettingsLocalDataSourceTest.kt
+++ b/data/settings/src/test/kotlin/com/sottti/android/app/template/data/settings/datasource/local/SettingsLocalDataSourceTest.kt
@@ -2,21 +2,21 @@ package com.sottti.android.app.template.data.settings.datasource.local
 
 import app.cash.turbine.test
 import com.google.common.truth.Truth
-import com.sottti.android.app.template.data.settings.datasource.local.managers.FakeSystemColorContrastManager
-import com.sottti.android.app.template.data.settings.datasource.local.managers.FakeThemeManager
+import com.sottti.android.app.template.data.settings.datasource.local.managers.SystemColorContrastManagerFake
+import com.sottti.android.app.template.data.settings.datasource.local.managers.ThemeManagerFake
 import com.sottti.android.app.template.domain.core.models.DynamicColor
 import com.sottti.android.app.template.domain.core.models.SystemColorContrast
 import com.sottti.android.app.template.domain.core.models.SystemTheme
-import com.sottti.android.app.template.domain.system.features.FakeSystemFeatures
+import com.sottti.android.app.template.domain.system.features.SystemFeaturesFake
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 
 internal class SettingsLocalDataSourceTest {
 
-    private lateinit var fakeSystemFeatures: FakeSystemFeatures
-    private lateinit var fakeSystemColorContrastManager: FakeSystemColorContrastManager
-    private lateinit var fakeThemeManager: FakeThemeManager
+    private lateinit var fakeSystemFeatures: SystemFeaturesFake
+    private lateinit var fakeSystemColorContrastManager: SystemColorContrastManagerFake
+    private lateinit var fakeThemeManager: ThemeManagerFake
     private lateinit var dataSource: SettingsLocalDataSource
     private var defaultSystemColorContrast = SystemColorContrast.StandardContrast
     private var defaultSystemFeatures = true
@@ -24,9 +24,9 @@ internal class SettingsLocalDataSourceTest {
 
     @Before
     fun setUp() {
-        fakeSystemFeatures = FakeSystemFeatures(default = defaultSystemFeatures)
-        fakeSystemColorContrastManager = FakeSystemColorContrastManager(defaultSystemColorContrast)
-        fakeThemeManager = FakeThemeManager(defaultTheme)
+        fakeSystemFeatures = SystemFeaturesFake(default = defaultSystemFeatures)
+        fakeSystemColorContrastManager = SystemColorContrastManagerFake(defaultSystemColorContrast)
+        fakeThemeManager = ThemeManagerFake(defaultTheme)
 
         dataSource = SettingsLocalDataSource(
             features = fakeSystemFeatures,

--- a/data/settings/src/test/kotlin/com/sottti/android/app/template/data/settings/datasource/local/managers/SystemColorContrastManagerImplTest.kt
+++ b/data/settings/src/test/kotlin/com/sottti/android/app/template/data/settings/datasource/local/managers/SystemColorContrastManagerImplTest.kt
@@ -11,7 +11,7 @@ import com.sottti.android.app.template.data.settings.datasource.local.mapper.HIG
 import com.sottti.android.app.template.data.settings.datasource.local.mapper.MEDIUM_CONTRAST_THRESHOLD
 import com.sottti.android.app.template.data.settings.datasource.local.mapper.STANDARD_CONTRAST_THRESHOLD
 import com.sottti.android.app.template.domain.core.models.SystemColorContrast
-import com.sottti.android.app.template.domain.system.features.FakeSystemFeatures
+import com.sottti.android.app.template.domain.system.features.SystemFeaturesFake
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
@@ -28,15 +28,15 @@ internal class SystemColorContrastManagerImplTest {
     private lateinit var context: Context
     private lateinit var manager: SystemColorContrastManager
     private lateinit var shadowApplication: ShadowApplication
-    private lateinit var systemFeatures: FakeSystemFeatures
-    private lateinit var uiModeManager: FakeUiModeManager
+    private lateinit var systemFeatures: SystemFeaturesFake
+    private lateinit var uiModeManager: UiModeManagerFake
 
     @Before
     fun setUp() {
         context = ApplicationProvider.getApplicationContext()
         shadowApplication = Shadows.shadowOf(context.applicationContext as Application)
-        systemFeatures = FakeSystemFeatures(default = true)
-        uiModeManager = FakeUiModeManager()
+        systemFeatures = SystemFeaturesFake(default = true)
+        uiModeManager = UiModeManagerFake()
         manager = SystemColorContrastManagerImpl(
             context = context,
             systemFeatures = systemFeatures,

--- a/data/settings/src/test/kotlin/com/sottti/android/app/template/data/settings/datasource/local/managers/SystemColorContrastManagerTestFake.kt
+++ b/data/settings/src/test/kotlin/com/sottti/android/app/template/data/settings/datasource/local/managers/SystemColorContrastManagerTestFake.kt
@@ -6,12 +6,12 @@ import com.sottti.android.app.template.domain.core.models.SystemColorContrast
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
-internal class FakeSystemColorContrastManagerTest {
+internal class SystemColorContrastManagerTestFake {
 
     @Test
     fun `when created, then it holds the provided default contrast`() {
         val defaultContrast = SystemColorContrast.HighContrast
-        val fake = FakeSystemColorContrastManager(default = defaultContrast)
+        val fake = SystemColorContrastManagerFake(default = defaultContrast)
 
         val actual = fake.getSystemColorContrast()
 
@@ -20,7 +20,7 @@ internal class FakeSystemColorContrastManagerTest {
 
     @Test
     fun `when setting a new contrast, then the current contrast level is updated`() {
-        val fake = FakeSystemColorContrastManager(default = SystemColorContrast.StandardContrast)
+        val fake = SystemColorContrastManagerFake(default = SystemColorContrast.StandardContrast)
         val newContrast = SystemColorContrast.MediumContrast
 
         fake.setContrast(newContrast)
@@ -34,7 +34,7 @@ internal class FakeSystemColorContrastManagerTest {
         runTest {
             val defaultContrast = SystemColorContrast.StandardContrast
             val newContrast = SystemColorContrast.LowContrast
-            val fake = FakeSystemColorContrastManager(default = defaultContrast)
+            val fake = SystemColorContrastManagerFake(default = defaultContrast)
 
             fake.observeSystemColorContrast().test {
                 Truth.assertThat(awaitItem()).isEqualTo(defaultContrast)

--- a/data/settings/src/test/kotlin/com/sottti/android/app/template/data/settings/datasource/local/managers/ThemeManagerTestFake.kt
+++ b/data/settings/src/test/kotlin/com/sottti/android/app/template/data/settings/datasource/local/managers/ThemeManagerTestFake.kt
@@ -6,12 +6,12 @@ import com.sottti.android.app.template.domain.core.models.SystemTheme
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
-internal class FakeThemeManagerTest {
+internal class ThemeManagerTestFake {
 
     @Test
     fun `when created, then it holds the provided default theme`() {
         val defaultTheme = SystemTheme.DarkSystemTheme
-        val fake = FakeThemeManager(default = defaultTheme)
+        val fake = ThemeManagerFake(default = defaultTheme)
 
         val actual = fake.getSystemTheme()
 
@@ -20,7 +20,7 @@ internal class FakeThemeManagerTest {
 
     @Test
     fun `when setting a new theme, then the current theme is updated`() {
-        val fake = FakeThemeManager(default = SystemTheme.DarkSystemTheme)
+        val fake = ThemeManagerFake(default = SystemTheme.DarkSystemTheme)
         val newTheme = SystemTheme.LightSystemTheme
 
         fake.setTheme(newTheme)
@@ -34,7 +34,7 @@ internal class FakeThemeManagerTest {
         runTest {
             val defaultTheme = SystemTheme.LightSystemTheme
             val newTheme = SystemTheme.DarkSystemTheme
-            val fake = FakeThemeManager(default = defaultTheme)
+            val fake = ThemeManagerFake(default = defaultTheme)
 
             fake.observeSystemTheme().test {
                 Truth.assertThat(awaitItem()).isEqualTo(defaultTheme)

--- a/data/settings/src/test/kotlin/com/sottti/android/app/template/data/settings/datasource/local/managers/UiModeManagerTestFake.kt
+++ b/data/settings/src/test/kotlin/com/sottti/android/app/template/data/settings/datasource/local/managers/UiModeManagerTestFake.kt
@@ -10,13 +10,13 @@ import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [Build.VERSION_CODES.UPSIDE_DOWN_CAKE])
-internal class FakeUiModeManagerTest {
+internal class UiModeManagerTestFake {
 
-    private lateinit var uiModeManager: FakeUiModeManager
+    private lateinit var uiModeManager: UiModeManagerFake
 
     @Before
     fun setUp() {
-        uiModeManager = FakeUiModeManager()
+        uiModeManager = UiModeManagerFake()
     }
 
     @Test

--- a/domain/items/src/main/kotlin/com/sottti/android/app/template/usecase/ObserveItemFake.kt
+++ b/domain/items/src/main/kotlin/com/sottti/android/app/template/usecase/ObserveItemFake.kt
@@ -6,7 +6,7 @@ import com.sottti.android.app.template.model.ItemId
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 
-public class FakeObserveItem : ObserveItem {
+public class ObserveItemFake : ObserveItem {
     private var itemFlow: Flow<Item> = emptyFlow()
     private var lastCalledItemId: ItemId? = null
 

--- a/domain/items/src/main/kotlin/com/sottti/android/app/template/usecase/ObserveItemsFake.kt
+++ b/domain/items/src/main/kotlin/com/sottti/android/app/template/usecase/ObserveItemsFake.kt
@@ -5,7 +5,7 @@ import com.sottti.android.app.template.model.Item
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
-public class FakeObserveItems : ObserveItems {
+public class ObserveItemsFake : ObserveItems {
 
     private var itemsFlow: Flow<PagingData<Item>> = flowOf(PagingData.empty())
 

--- a/domain/items/src/test/kotlin/com/sottti/android/app/template/domain/usecase/ObserveItemsTestFake.kt
+++ b/domain/items/src/test/kotlin/com/sottti/android/app/template/domain/usecase/ObserveItemsTestFake.kt
@@ -5,19 +5,19 @@ import androidx.paging.testing.asSnapshot
 import com.google.common.truth.Truth.assertThat
 import com.sottti.android.app.template.fixtures.listOfTwoItems
 import com.sottti.android.app.template.model.Item
-import com.sottti.android.app.template.usecase.FakeObserveItems
+import com.sottti.android.app.template.usecase.ObserveItemsFake
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
 
-internal class FakeObserveItemsTest {
+internal class ObserveItemsTestFake {
 
-    private lateinit var observeItems: FakeObserveItems
+    private lateinit var observeItems: ObserveItemsFake
 
     @Before
     fun setUp() {
-        observeItems = FakeObserveItems()
+        observeItems = ObserveItemsFake()
     }
 
     @Test

--- a/domain/system-features/src/main/kotlin/com/sottti/android/app/template/domain/system/features/SystemFeaturesFake.kt
+++ b/domain/system-features/src/main/kotlin/com/sottti/android/app/template/domain/system/features/SystemFeaturesFake.kt
@@ -1,6 +1,6 @@
 package com.sottti.android.app.template.domain.system.features
 
-public class FakeSystemFeatures(
+public class SystemFeaturesFake(
     default: Boolean,
 ) : SystemFeatures {
 

--- a/domain/system-features/src/test/kotlin/com/sottti/android/app/template/domain/system/features/SystemFeaturesTestFake.kt
+++ b/domain/system-features/src/test/kotlin/com/sottti/android/app/template/domain/system/features/SystemFeaturesTestFake.kt
@@ -3,11 +3,11 @@ package com.sottti.android.app.template.domain.system.features
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
-internal class FakeSystemFeaturesTest {
+internal class SystemFeaturesTestFake {
 
     @Test
     fun `when created with default true, then all features are available`() {
-        val fake = FakeSystemFeatures(default = true)
+        val fake = SystemFeaturesFake(default = true)
 
         assertThat(fake.systemColorContrastAvailable()).isTrue()
         assertThat(fake.systemDynamicColorAvailable()).isTrue()
@@ -16,7 +16,7 @@ internal class FakeSystemFeaturesTest {
 
     @Test
     fun `when created with default false, then all features are unavailable`() {
-        val fake = FakeSystemFeatures(default = false)
+        val fake = SystemFeaturesFake(default = false)
 
         assertThat(fake.systemColorContrastAvailable()).isFalse()
         assertThat(fake.systemDynamicColorAvailable()).isFalse()
@@ -25,7 +25,7 @@ internal class FakeSystemFeaturesTest {
 
     @Test
     fun `when updating contrast availability, then only the contrast feature is updated`() {
-        val fake = FakeSystemFeatures(default = true)
+        val fake = SystemFeaturesFake(default = true)
 
         fake.setSystemColorContrastAvailable(false)
 
@@ -36,7 +36,7 @@ internal class FakeSystemFeaturesTest {
 
     @Test
     fun `when updating dynamic color availability, then only the dynamic color feature is updated`() {
-        val fake = FakeSystemFeatures(default = false)
+        val fake = SystemFeaturesFake(default = false)
 
         fake.setSystemDynamicColorAvailable(true)
 
@@ -47,7 +47,7 @@ internal class FakeSystemFeaturesTest {
 
     @Test
     fun `when updating theming availability, then only the theming feature is updated`() {
-        val fake = FakeSystemFeatures(default = true)
+        val fake = SystemFeaturesFake(default = true)
 
         fake.setLightDarkSystemThemingAvailable(false)
 

--- a/presentation/features/item-details/src/test/kotlin/com/sottti/android/app/template/presentation/item/details/data/ItemDetailsViewModelTest.kt
+++ b/presentation/features/item-details/src/test/kotlin/com/sottti/android/app/template/presentation/item/details/data/ItemDetailsViewModelTest.kt
@@ -5,9 +5,9 @@ import com.google.common.truth.Truth.assertThat
 import com.sottti.android.app.template.fixtures.fixtureItem1
 import com.sottti.android.app.template.presentation.item.details.model.ItemDetailsActions.NavigateBack
 import com.sottti.android.app.template.presentation.item.details.model.ItemDetailsState
-import com.sottti.android.app.template.presentation.navigation.manager.FakeNavigationManager
+import com.sottti.android.app.template.presentation.navigation.manager.NavigationManagerFake
 import com.sottti.android.app.template.presentation.navigation.model.NavigationCommand
-import com.sottti.android.app.template.usecase.FakeObserveItem
+import com.sottti.android.app.template.usecase.ObserveItemFake
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -15,14 +15,14 @@ import org.junit.Test
 
 internal class ItemDetailsViewModelTest {
 
-    private lateinit var navigationManager: FakeNavigationManager
-    private lateinit var observeItem: FakeObserveItem
+    private lateinit var navigationManager: NavigationManagerFake
+    private lateinit var observeItem: ObserveItemFake
     private lateinit var viewModel: ItemDetailsViewModel
 
     @Before
     fun setUp() {
-        navigationManager = FakeNavigationManager()
-        observeItem = FakeObserveItem()
+        navigationManager = NavigationManagerFake()
+        observeItem = ObserveItemFake()
     }
 
     @Test

--- a/presentation/features/items-list/src/test/kotlin/com/sottti/android/app/template/presentation/items/list/data/ItemsListViewModelTest.kt
+++ b/presentation/features/items-list/src/test/kotlin/com/sottti/android/app/template/presentation/items/list/data/ItemsListViewModelTest.kt
@@ -6,10 +6,10 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import com.sottti.android.app.template.fixtures.listOfTwoItems
 import com.sottti.android.app.template.presentation.items.list.model.ItemsListActions.ShowItemDetail
-import com.sottti.android.app.template.presentation.navigation.manager.FakeNavigationManager
+import com.sottti.android.app.template.presentation.navigation.manager.NavigationManagerFake
 import com.sottti.android.app.template.presentation.navigation.model.NavigationCommand
 import com.sottti.android.app.template.presentation.navigation.model.NavigationDestination.ItemDetail
-import com.sottti.android.app.template.usecase.FakeObserveItems
+import com.sottti.android.app.template.usecase.ObserveItemsFake
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -24,13 +24,13 @@ internal class ItemsListViewModelTest {
     private val pagingData = PagingData.from(items)
     private val pagingFlow = flowOf(pagingData)
 
-    private lateinit var navigationManager: FakeNavigationManager
-    private lateinit var observeItems: FakeObserveItems
+    private lateinit var navigationManager: NavigationManagerFake
+    private lateinit var observeItems: ObserveItemsFake
 
     @Before
     fun setup() {
-        navigationManager = FakeNavigationManager()
-        observeItems = FakeObserveItems()
+        navigationManager = NavigationManagerFake()
+        observeItems = ObserveItemsFake()
     }
 
     @Test

--- a/presentation/navigation-impl/src/androidTest/kotlin/com/sottti/android/app/template/presentation/navigation/impl/NavigatorTest.kt
+++ b/presentation/navigation-impl/src/androidTest/kotlin/com/sottti/android/app/template/presentation/navigation/impl/NavigatorTest.kt
@@ -12,7 +12,7 @@ import androidx.navigation3.runtime.NavKey
 import com.sottti.android.app.template.presentation.navigation.impl.fakes.ITEM_DETAIL_FEATURE_TEST_TAG
 import com.sottti.android.app.template.presentation.navigation.impl.fakes.PULLY_LIST_FEATURE_TEST_TAG
 import com.sottti.android.app.template.presentation.navigation.impl.fakes.fakeNavigationEntries
-import com.sottti.android.app.template.presentation.navigation.manager.FakeNavigationManager
+import com.sottti.android.app.template.presentation.navigation.manager.NavigationManagerFake
 import com.sottti.android.app.template.presentation.navigation.model.NavigationDestination.ItemDetail
 import com.sottti.android.app.template.presentation.navigation.model.NavigationDestination.ItemsList
 import org.junit.Before
@@ -24,14 +24,14 @@ internal class NavigatorTest {
     @get:Rule
     val composeTestRule = createComposeRule()
 
-    private lateinit var navigationManager: FakeNavigationManager
+    private lateinit var navigationManager: NavigationManagerFake
 
     private val entryProvider: EntryProvider<NavKey> = fakeNavigationEntries()
 
 
     @Before
     fun setUp() {
-        navigationManager = FakeNavigationManager()
+        navigationManager = NavigationManagerFake()
     }
 
     @Test
@@ -197,7 +197,7 @@ internal class NavigatorTest {
         var currentNavigationManager by mutableStateOf(navigationManager)
         composeTestRule.setContent { Navigator(currentNavigationManager, entryProvider) }
 
-        val newManager = FakeNavigationManager()
+        val newManager = NavigationManagerFake()
         composeTestRule.runOnIdle { currentNavigationManager = newManager }
 
         composeTestRule.runOnIdle { newManager.navigateTo(ItemDetail(itemId = 1)) }

--- a/presentation/navigation/src/main/kotlin/com/sottti/android/app/template/presentation/navigation/manager/NavigationManagerFake.kt
+++ b/presentation/navigation/src/main/kotlin/com/sottti/android/app/template/presentation/navigation/manager/NavigationManagerFake.kt
@@ -6,7 +6,7 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.receiveAsFlow
 
-public class FakeNavigationManager : NavigationManager {
+public class NavigationManagerFake : NavigationManager {
     private val _commands = Channel<NavigationCommand>(Channel.BUFFERED)
 
     override fun commands(): Flow<NavigationCommand> = _commands.receiveAsFlow()


### PR DESCRIPTION
## Summary
- rename fake data sources, DAOs, and paging utilities to use a `Fake` suffix and update their consumers
- align settings and domain fake helpers with the suffix convention and adjust associated tests
- update presentation layer fakes and view model tests to use the new names

## Testing
- `./gradlew test` *(fails: Java 17 toolchain not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_690638897140832e826a53bbe7c5c7cb