### PR TITLE
Rename test variables to remove fake prefix

### DIFF
--- a/data/settings/src/test/kotlin/com/sottti/android/app/template/data/settings/datasource/local/SettingsLocalDataSourceTest.kt
+++ b/data/settings/src/test/kotlin/com/sottti/android/app/template/data/settings/datasource/local/SettingsLocalDataSourceTest.kt
@@ -14,9 +14,9 @@ import org.junit.Test
 
 internal class SettingsLocalDataSourceTest {
 
-    private lateinit var fakeSystemFeatures: SystemFeaturesFake
-    private lateinit var fakeSystemColorContrastManager: SystemColorContrastManagerFake
-    private lateinit var fakeThemeManager: ThemeManagerFake
+    private lateinit var systemFeatures: SystemFeaturesFake
+    private lateinit var systemColorContrastManager: SystemColorContrastManagerFake
+    private lateinit var themeManager: ThemeManagerFake
     private lateinit var dataSource: SettingsLocalDataSource
     private var defaultSystemColorContrast = SystemColorContrast.StandardContrast
     private var defaultSystemFeatures = true
@@ -24,21 +24,21 @@ internal class SettingsLocalDataSourceTest {
 
     @Before
     fun setUp() {
-        fakeSystemFeatures = SystemFeaturesFake(default = defaultSystemFeatures)
-        fakeSystemColorContrastManager = SystemColorContrastManagerFake(defaultSystemColorContrast)
-        fakeThemeManager = ThemeManagerFake(defaultTheme)
+        systemFeatures = SystemFeaturesFake(default = defaultSystemFeatures)
+        systemColorContrastManager = SystemColorContrastManagerFake(defaultSystemColorContrast)
+        themeManager = ThemeManagerFake(defaultTheme)
 
         dataSource = SettingsLocalDataSource(
-            features = fakeSystemFeatures,
-            systemColorContrastManager = fakeSystemColorContrastManager,
-            themeManager = fakeThemeManager,
+            features = systemFeatures,
+            systemColorContrastManager = systemColorContrastManager,
+            themeManager = themeManager,
         )
     }
 
     @Test
     fun `when getting system color contrast, then the value from the manager is returned`() {
         val expectedContrast = SystemColorContrast.HighContrast
-        fakeSystemColorContrastManager.setContrast(expectedContrast)
+        systemColorContrastManager.setContrast(expectedContrast)
         val actualContrast = dataSource.getSystemColorContrast()
         Truth.assertThat(actualContrast).isEqualTo(expectedContrast)
     }
@@ -48,7 +48,7 @@ internal class SettingsLocalDataSourceTest {
         runTest {
             dataSource.observeSystemColorContrast().test {
                 Truth.assertThat(awaitItem()).isEqualTo(defaultSystemColorContrast)
-                fakeSystemColorContrastManager.setContrast(SystemColorContrast.MediumContrast)
+                systemColorContrastManager.setContrast(SystemColorContrast.MediumContrast)
                 Truth.assertThat(awaitItem()).isEqualTo(SystemColorContrast.MediumContrast)
                 cancelAndIgnoreRemainingEvents()
             }
@@ -56,14 +56,14 @@ internal class SettingsLocalDataSourceTest {
 
     @Test
     fun `when observing dynamic color, it emits the correct state and completes`() = runTest {
-        fakeSystemFeatures.setSystemDynamicColorAvailable(true)
+        systemFeatures.setSystemDynamicColorAvailable(true)
 
         dataSource.observeDynamicColor().test {
             Truth.assertThat(awaitItem()).isEqualTo(DynamicColor(true))
             awaitComplete()
         }
 
-        fakeSystemFeatures.setSystemDynamicColorAvailable(false)
+        systemFeatures.setSystemDynamicColorAvailable(false)
         dataSource.observeDynamicColor().test {
             Truth.assertThat(awaitItem()).isEqualTo(DynamicColor(false))
             awaitComplete()
@@ -75,7 +75,7 @@ internal class SettingsLocalDataSourceTest {
     fun `when observing system theme, then the flow from the manager is returned`() = runTest {
         dataSource.observeSystemTheme().test {
             Truth.assertThat(awaitItem()).isEqualTo(defaultTheme)
-            fakeThemeManager.setTheme(SystemTheme.DarkSystemTheme)
+            themeManager.setTheme(SystemTheme.DarkSystemTheme)
             Truth.assertThat(awaitItem()).isEqualTo(SystemTheme.DarkSystemTheme)
             cancelAndIgnoreRemainingEvents()
         }
@@ -84,7 +84,7 @@ internal class SettingsLocalDataSourceTest {
     @Test
     fun `when getting system theme, then the value from the manager is returned`() {
         val expectedTheme = SystemTheme.DarkSystemTheme
-        fakeThemeManager.setTheme(expectedTheme)
+        themeManager.setTheme(expectedTheme)
         val actualTheme = dataSource.getSystemTheme()
         Truth.assertThat(actualTheme).isEqualTo(expectedTheme)
     }

--- a/data/settings/src/test/kotlin/com/sottti/android/app/template/data/settings/datasource/local/managers/SystemColorContrastManagerTestFake.kt
+++ b/data/settings/src/test/kotlin/com/sottti/android/app/template/data/settings/datasource/local/managers/SystemColorContrastManagerTestFake.kt
@@ -11,20 +11,20 @@ internal class SystemColorContrastManagerTestFake {
     @Test
     fun `when created, then it holds the provided default contrast`() {
         val defaultContrast = SystemColorContrast.HighContrast
-        val fake = SystemColorContrastManagerFake(default = defaultContrast)
+        val manager = SystemColorContrastManagerFake(default = defaultContrast)
 
-        val actual = fake.getSystemColorContrast()
+        val actual = manager.getSystemColorContrast()
 
         Truth.assertThat(actual).isEqualTo(defaultContrast)
     }
 
     @Test
     fun `when setting a new contrast, then the current contrast level is updated`() {
-        val fake = SystemColorContrastManagerFake(default = SystemColorContrast.StandardContrast)
+        val manager = SystemColorContrastManagerFake(default = SystemColorContrast.StandardContrast)
         val newContrast = SystemColorContrast.MediumContrast
 
-        fake.setContrast(newContrast)
-        val actual = fake.getSystemColorContrast()
+        manager.setContrast(newContrast)
+        val actual = manager.getSystemColorContrast()
 
         Truth.assertThat(actual).isEqualTo(newContrast)
     }
@@ -34,12 +34,12 @@ internal class SystemColorContrastManagerTestFake {
         runTest {
             val defaultContrast = SystemColorContrast.StandardContrast
             val newContrast = SystemColorContrast.LowContrast
-            val fake = SystemColorContrastManagerFake(default = defaultContrast)
+            val manager = SystemColorContrastManagerFake(default = defaultContrast)
 
-            fake.observeSystemColorContrast().test {
+            manager.observeSystemColorContrast().test {
                 Truth.assertThat(awaitItem()).isEqualTo(defaultContrast)
 
-                fake.setContrast(newContrast)
+                manager.setContrast(newContrast)
 
                 Truth.assertThat(awaitItem()).isEqualTo(newContrast)
 

--- a/data/settings/src/test/kotlin/com/sottti/android/app/template/data/settings/datasource/local/managers/ThemeManagerTestFake.kt
+++ b/data/settings/src/test/kotlin/com/sottti/android/app/template/data/settings/datasource/local/managers/ThemeManagerTestFake.kt
@@ -11,20 +11,20 @@ internal class ThemeManagerTestFake {
     @Test
     fun `when created, then it holds the provided default theme`() {
         val defaultTheme = SystemTheme.DarkSystemTheme
-        val fake = ThemeManagerFake(default = defaultTheme)
+        val themeManager = ThemeManagerFake(default = defaultTheme)
 
-        val actual = fake.getSystemTheme()
+        val actual = themeManager.getSystemTheme()
 
         Truth.assertThat(actual).isEqualTo(defaultTheme)
     }
 
     @Test
     fun `when setting a new theme, then the current theme is updated`() {
-        val fake = ThemeManagerFake(default = SystemTheme.DarkSystemTheme)
+        val themeManager = ThemeManagerFake(default = SystemTheme.DarkSystemTheme)
         val newTheme = SystemTheme.LightSystemTheme
 
-        fake.setTheme(newTheme)
-        val actual = fake.getSystemTheme()
+        themeManager.setTheme(newTheme)
+        val actual = themeManager.getSystemTheme()
 
         Truth.assertThat(actual).isEqualTo(newTheme)
     }
@@ -34,12 +34,12 @@ internal class ThemeManagerTestFake {
         runTest {
             val defaultTheme = SystemTheme.LightSystemTheme
             val newTheme = SystemTheme.DarkSystemTheme
-            val fake = ThemeManagerFake(default = defaultTheme)
+            val themeManager = ThemeManagerFake(default = defaultTheme)
 
-            fake.observeSystemTheme().test {
+            themeManager.observeSystemTheme().test {
                 Truth.assertThat(awaitItem()).isEqualTo(defaultTheme)
 
-                fake.setTheme(newTheme)
+                themeManager.setTheme(newTheme)
 
                 Truth.assertThat(awaitItem()).isEqualTo(newTheme)
 

--- a/domain/system-features/src/test/kotlin/com/sottti/android/app/template/domain/system/features/SystemFeaturesTestFake.kt
+++ b/domain/system-features/src/test/kotlin/com/sottti/android/app/template/domain/system/features/SystemFeaturesTestFake.kt
@@ -7,52 +7,52 @@ internal class SystemFeaturesTestFake {
 
     @Test
     fun `when created with default true, then all features are available`() {
-        val fake = SystemFeaturesFake(default = true)
+        val systemFeatures = SystemFeaturesFake(default = true)
 
-        assertThat(fake.systemColorContrastAvailable()).isTrue()
-        assertThat(fake.systemDynamicColorAvailable()).isTrue()
-        assertThat(fake.lightDarkSystemThemingAvailable()).isTrue()
+        assertThat(systemFeatures.systemColorContrastAvailable()).isTrue()
+        assertThat(systemFeatures.systemDynamicColorAvailable()).isTrue()
+        assertThat(systemFeatures.lightDarkSystemThemingAvailable()).isTrue()
     }
 
     @Test
     fun `when created with default false, then all features are unavailable`() {
-        val fake = SystemFeaturesFake(default = false)
+        val systemFeatures = SystemFeaturesFake(default = false)
 
-        assertThat(fake.systemColorContrastAvailable()).isFalse()
-        assertThat(fake.systemDynamicColorAvailable()).isFalse()
-        assertThat(fake.lightDarkSystemThemingAvailable()).isFalse()
+        assertThat(systemFeatures.systemColorContrastAvailable()).isFalse()
+        assertThat(systemFeatures.systemDynamicColorAvailable()).isFalse()
+        assertThat(systemFeatures.lightDarkSystemThemingAvailable()).isFalse()
     }
 
     @Test
     fun `when updating contrast availability, then only the contrast feature is updated`() {
-        val fake = SystemFeaturesFake(default = true)
+        val systemFeatures = SystemFeaturesFake(default = true)
 
-        fake.setSystemColorContrastAvailable(false)
+        systemFeatures.setSystemColorContrastAvailable(false)
 
-        assertThat(fake.systemColorContrastAvailable()).isFalse()
-        assertThat(fake.systemDynamicColorAvailable()).isTrue()
-        assertThat(fake.lightDarkSystemThemingAvailable()).isTrue()
+        assertThat(systemFeatures.systemColorContrastAvailable()).isFalse()
+        assertThat(systemFeatures.systemDynamicColorAvailable()).isTrue()
+        assertThat(systemFeatures.lightDarkSystemThemingAvailable()).isTrue()
     }
 
     @Test
     fun `when updating dynamic color availability, then only the dynamic color feature is updated`() {
-        val fake = SystemFeaturesFake(default = false)
+        val systemFeatures = SystemFeaturesFake(default = false)
 
-        fake.setSystemDynamicColorAvailable(true)
+        systemFeatures.setSystemDynamicColorAvailable(true)
 
-        assertThat(fake.systemColorContrastAvailable()).isFalse()
-        assertThat(fake.systemDynamicColorAvailable()).isTrue()
-        assertThat(fake.lightDarkSystemThemingAvailable()).isFalse()
+        assertThat(systemFeatures.systemColorContrastAvailable()).isFalse()
+        assertThat(systemFeatures.systemDynamicColorAvailable()).isTrue()
+        assertThat(systemFeatures.lightDarkSystemThemingAvailable()).isFalse()
     }
 
     @Test
     fun `when updating theming availability, then only the theming feature is updated`() {
-        val fake = SystemFeaturesFake(default = true)
+        val systemFeatures = SystemFeaturesFake(default = true)
 
-        fake.setLightDarkSystemThemingAvailable(false)
+        systemFeatures.setLightDarkSystemThemingAvailable(false)
 
-        assertThat(fake.systemColorContrastAvailable()).isTrue()
-        assertThat(fake.systemDynamicColorAvailable()).isTrue()
-        assertThat(fake.lightDarkSystemThemingAvailable()).isFalse()
+        assertThat(systemFeatures.systemColorContrastAvailable()).isTrue()
+        assertThat(systemFeatures.systemDynamicColorAvailable()).isTrue()
+        assertThat(systemFeatures.lightDarkSystemThemingAvailable()).isFalse()
     }
 }


### PR DESCRIPTION
## Summary
- rename test properties and local variables to avoid using the word "fake"
- keep existing fake implementations referenced while clarifying variable names

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69063be977b0832eba1f4d7b6717cc71