### PR TITLE
Document explicit API mode usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ This template is packed with the latest libraries and tools from the Android eco
   communication.
 * **Serialization:** [Kotlinx.serialization](https://github.com/Kotlin/kotlinx.serialization) (used
   with Ktor) for fast and modern JSON parsing.
+* **Build Configuration:** Kotlin [explicit API mode](https://kotlinlang.org/docs/whatsnew15.html#explicit-api-mode) is enabled across modules to keep public APIs intentional and well-documented.
 * **Testing:**
     * **Unit Tests:** [JUnit 4](https://junit.org/junit4/)
     * **Screenshot Tests:** [Paparazzi](https://github.com/cashapp/paparazzi)


### PR DESCRIPTION
## Summary
- update the README feature list to note that Kotlin explicit API mode is enabled across modules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69074ff6e4e4832e97ba93cbfd9e1b33