### PR TITLE
Clarify README navigation module scope and edge-to-edge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,9 @@ This template is packed with the latest libraries and tools from the Android eco
   whenever the network is available.
 * **Navigation infrastructure:** A dedicated Compose Navigation 3 stack coordinates screen changes
   via a `NavigationManager`, with `Navigator` components observing command channels and handling
-  saveable state, back stack pops, and simultaneous navigation requests.
+  saveable state, back stack pops, and simultaneous navigation requests. All routing code lives in
+  the dedicated `presentation:navigation` module so feature modules stay navigation-agnostic and
+  decoupled from the implementation details.
 * **Snapshot tooling:** The `presentation` module includes a Paparazzi test toolkit featuring a
   custom Pixel 10 Pro XL device profile and helpers that generate day/night parameter sets for rich
   screenshot coverage.
@@ -99,6 +101,8 @@ This template is packed with the latest libraries and tools from the Android eco
 * **Streamlined startup:** A Hilt-enabled `Application`, splash activity, and edge-to-edge
   `HomeActivity` combine with the navigation manager to launch directly into themed Compose content
   with minimal boilerplate.
+* **Edge-to-edge ready:** Compose screens are rendered behind the system bars, with window insets
+  managed centrally so features automatically inherit full-height layouts.
 
 ## 🏗️ Project Structure
 


### PR DESCRIPTION
## Summary
- document that navigation implementation lives entirely in the `presentation:navigation` module so features stay decoupled
- highlight that the template ships with edge-to-edge rendering and centrally managed insets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69079deb0a5c832ebcb790b7355d09a2